### PR TITLE
Float32 kernel

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,17 @@
 repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.10
+    hooks:
+      - id: ruff
+        args: [--fix, --show-fixes]
+      - id: ruff-format
   - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 6.0.1
     hooks:
       - id: isort
         args: ["--profile", "black", "--filter-files"]
-  - repo: https://github.com/psf/black
-    rev: 22.6.0
-    hooks:
-      - id: black-jupyter
   - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 7.2.0
     hooks:
       - id: flake8
         args: [--max-line-length=88, "--extend-ignore=E203,E741"]

--- a/docs/changes/6.optimization.rst
+++ b/docs/changes/6.optimization.rst
@@ -1,0 +1,11 @@
+### Dependency and Configuration Updates
+* Updated `.pre-commit-config.yaml` to include the `ruff` linter and updated versions of `isort` and `flake8`. Removed `black` from the configuration. 
+
+### CUDA Kernels and Bindings Enhancements
+* Added new CUDA kernels (`compute_phase_kernel32` and `compute_inverse_phase_kernel32`) in `radioft/cuda/kernels/cuda_phase_kernel32.cu` to support float32 precision for phase matrix computations.
+* Refactored existing kernels in `radioft/cuda/kernels/cuda_phase_kernel.cu` to improve code formatting and readability, including consistent formatting for function signatures and kernel launches. 
+* Added PyBind11 bindings in `radioft/cuda/cuda_bindings.cpp` to expose both float32 and float64 CUDA kernel functions to Python. 
+
+### PyTorch Integration and API Improvements
+* Updated `radioft/dft/dft.py` to add support for both float32 and float64 precision in the `HybridPyTorchCudaDFT` class. Introduced a `dtype` parameter in the constructor and `float64` flags in the `forward` and `inverse` methods to toggle precision. 
+* Modified tensor initialization and typecasting in `forward` and `inverse` methods to dynamically set precision based on the `float64` flag.

--- a/radioft/cuda/cuda_bindings.cpp
+++ b/radioft/cuda/cuda_bindings.cpp
@@ -1,0 +1,35 @@
+#include <torch/extension.h>
+
+torch::Tensor
+compute_phase_matrix(torch::Tensor l_coords, torch::Tensor m_coords,
+                     torch::Tensor n_coords, torch::Tensor u_coords,
+                     torch::Tensor v_coords, torch::Tensor w_coords);
+
+torch::Tensor
+compute_inverse_phase_matrix(torch::Tensor l_coords, torch::Tensor m_coords,
+                             torch::Tensor n_coords, torch::Tensor u_coords,
+                             torch::Tensor v_coords, torch::Tensor w_coords);
+
+torch::Tensor
+compute_phase_matrix32(torch::Tensor l_coords, torch::Tensor m_coords,
+                       torch::Tensor n_coords, torch::Tensor u_coords,
+                       torch::Tensor v_coords, torch::Tensor w_coords);
+
+torch::Tensor
+compute_inverse_phase_matrix32(torch::Tensor l_coords, torch::Tensor m_coords,
+                               torch::Tensor n_coords, torch::Tensor u_coords,
+                               torch::Tensor v_coords, torch::Tensor w_coords);
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  // float64 implemetations
+  m.def("compute_phase_matrix", &compute_phase_matrix,
+        "Compute phase matrix with high precision");
+  m.def("compute_inverse_phase_matrix", &compute_inverse_phase_matrix,
+        "Compute inverse phase matrix with high precision");
+
+  // float32 implemetations
+  m.def("compute_inverse_phase_matrix32", &compute_inverse_phase_matrix32,
+        "Compute inverse phase matrix with float32 precision");
+  m.def("compute_phase_matrix32", &compute_phase_matrix32,
+        "Compute phase matrix with float32 precision");
+}

--- a/radioft/cuda/kernels/cuda_phase_kernel.cu
+++ b/radioft/cuda/kernels/cuda_phase_kernel.cu
@@ -1,7 +1,7 @@
-#include <torch/extension.h>
+#include <cuComplex.h>
 #include <cuda.h>
 #include <cuda_runtime.h>
-#include <cuComplex.h>
+#include <torch/extension.h>
 
 // Constants for numerical stability
 #define PI_DOUBLE 3.14159265358979323846
@@ -11,96 +11,76 @@
  * This kernel computes the phase matrix with double precision
  */
 __global__ void compute_high_precision_phase_kernel(
-    const double* __restrict__ l_coords,
-    const double* __restrict__ m_coords,
-    const double* __restrict__ n_coords,
-    const double* __restrict__ u_coords,
-    const double* __restrict__ v_coords,
-    const double* __restrict__ w_coords,
-    double* __restrict__ phase_matrix,
-    int num_vis,
-    int num_pixels
-) {
-    // Each thread computes one element of the phase matrix
-    int vis_idx = blockIdx.x * blockDim.x + threadIdx.x;
-    int pixel_idx = blockIdx.y * blockDim.y + threadIdx.y;
-    
-    if (vis_idx < num_vis && pixel_idx < num_pixels) {
-        // Load coordinates with high precision
-        double u = u_coords[vis_idx];
-        double v = v_coords[vis_idx];
-        double w = w_coords[vis_idx];
-        double l = l_coords[pixel_idx];
-        double m = m_coords[pixel_idx];
-        double n = n_coords[pixel_idx] - 1.0; // n - 1
-        
-        // Careful phase computation to maintain precision
-        // Calculate components separately to minimize rounding errors
-        double ul = u * l;
-        double vm = v * m;
-        double wn = w * n;
-        
-        // Combine terms carefully
-        double sum1 = ul + vm;
-        double sum2 = sum1 + wn;
-        
-        // Final phase calculation
-        double phase = -2.0 * PI_DOUBLE * sum2;
-        
-        // Store phase in matrix
-        phase_matrix[vis_idx * num_pixels + pixel_idx] = phase;
-    }
-}
+    const double *__restrict__ l_coords, const double *__restrict__ m_coords,
+    const double *__restrict__ n_coords, const double *__restrict__ u_coords,
+    const double *__restrict__ v_coords, const double *__restrict__ w_coords,
+    double *__restrict__ phase_matrix, int num_vis, int num_pixels) {
+  // Each thread computes one element of the phase matrix
+  int vis_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  int pixel_idx = blockIdx.y * blockDim.y + threadIdx.y;
 
+  if (vis_idx < num_vis && pixel_idx < num_pixels) {
+    // Load coordinates with high precision
+    double u = u_coords[vis_idx];
+    double v = v_coords[vis_idx];
+    double w = w_coords[vis_idx];
+    double l = l_coords[pixel_idx];
+    double m = m_coords[pixel_idx];
+    double n = n_coords[pixel_idx] - 1.0; // n - 1
+
+    // Careful phase computation to maintain precision
+    // Calculate components separately to minimize rounding errors
+    double ul = u * l;
+    double vm = v * m;
+    double wn = w * n;
+
+    // Combine terms carefully
+    double sum1 = ul + vm;
+    double sum2 = sum1 + wn;
+
+    // Final phase calculation
+    double phase = -2.0 * PI_DOUBLE * sum2;
+
+    // Store phase in matrix
+    phase_matrix[vis_idx * num_pixels + pixel_idx] = phase;
+  }
+}
 
 // Wrapper functions for PyTorch integration
 
-torch::Tensor compute_phase_matrix(
-    torch::Tensor l_coords,
-    torch::Tensor m_coords,
-    torch::Tensor n_coords,
-    torch::Tensor u_coords,
-    torch::Tensor v_coords,
-    torch::Tensor w_coords
-) {
-    // Validate inputs
-    TORCH_CHECK(l_coords.is_cuda(), "l_coords must be a CUDA tensor");
-    TORCH_CHECK(m_coords.is_cuda(), "m_coords must be a CUDA tensor");
-    TORCH_CHECK(n_coords.is_cuda(), "n_coords must be a CUDA tensor");
-    TORCH_CHECK(u_coords.is_cuda(), "u_coords must be a CUDA tensor");
-    TORCH_CHECK(v_coords.is_cuda(), "v_coords must be a CUDA tensor");
-    TORCH_CHECK(w_coords.is_cuda(), "w_coords must be a CUDA tensor");
-    
-    int num_pixels = l_coords.size(0);
-    int num_vis = u_coords.size(0);
-    
-    // Create output tensor
-    auto options = torch::TensorOptions()
-                       .dtype(torch::kFloat64)
-                       .device(l_coords.device());
-    auto phase_matrix = torch::empty({num_vis, num_pixels}, options);
-    
-    // Set up kernel execution
-    dim3 threads_per_block(16, 16);
-    dim3 num_blocks(
-        (num_vis + threads_per_block.x - 1) / threads_per_block.x,
-        (num_pixels + threads_per_block.y - 1) / threads_per_block.y
-    );
-    
-    // Launch kernel
-    compute_high_precision_phase_kernel<<<num_blocks, threads_per_block>>>(
-        l_coords.data_ptr<double>(),
-        m_coords.data_ptr<double>(),
-        n_coords.data_ptr<double>(),
-        u_coords.data_ptr<double>(),
-        v_coords.data_ptr<double>(),
-        w_coords.data_ptr<double>(),
-        phase_matrix.data_ptr<double>(),
-        num_vis,
-        num_pixels
-    );
-    
-    return phase_matrix;
+torch::Tensor
+compute_phase_matrix(torch::Tensor l_coords, torch::Tensor m_coords,
+                     torch::Tensor n_coords, torch::Tensor u_coords,
+                     torch::Tensor v_coords, torch::Tensor w_coords) {
+  // Validate inputs
+  TORCH_CHECK(l_coords.is_cuda(), "l_coords must be a CUDA tensor");
+  TORCH_CHECK(m_coords.is_cuda(), "m_coords must be a CUDA tensor");
+  TORCH_CHECK(n_coords.is_cuda(), "n_coords must be a CUDA tensor");
+  TORCH_CHECK(u_coords.is_cuda(), "u_coords must be a CUDA tensor");
+  TORCH_CHECK(v_coords.is_cuda(), "v_coords must be a CUDA tensor");
+  TORCH_CHECK(w_coords.is_cuda(), "w_coords must be a CUDA tensor");
+
+  int num_pixels = l_coords.size(0);
+  int num_vis = u_coords.size(0);
+
+  // Create output tensor
+  auto options =
+      torch::TensorOptions().dtype(torch::kFloat64).device(l_coords.device());
+  auto phase_matrix = torch::empty({num_vis, num_pixels}, options);
+
+  // Set up kernel execution
+  dim3 threads_per_block(16, 16);
+  dim3 num_blocks((num_vis + threads_per_block.x - 1) / threads_per_block.x,
+                  (num_pixels + threads_per_block.y - 1) / threads_per_block.y);
+
+  // Launch kernel
+  compute_high_precision_phase_kernel<<<num_blocks, threads_per_block>>>(
+      l_coords.data_ptr<double>(), m_coords.data_ptr<double>(),
+      n_coords.data_ptr<double>(), u_coords.data_ptr<double>(),
+      v_coords.data_ptr<double>(), w_coords.data_ptr<double>(),
+      phase_matrix.data_ptr<double>(), num_vis, num_pixels);
+
+  return phase_matrix;
 }
 
 /**
@@ -109,98 +89,73 @@ torch::Tensor compute_phase_matrix(
  * and POSITIVE sign for inverse DFT
  */
 __global__ void compute_high_precision_inverse_phase_kernel(
-    const double* __restrict__ l_coords,
-    const double* __restrict__ m_coords,
-    const double* __restrict__ n_coords,
-    const double* __restrict__ u_coords,
-    const double* __restrict__ v_coords,
-    const double* __restrict__ w_coords,
-    double* __restrict__ phase_matrix,
-    int num_vis,
-    int num_pixels
-) {
-    // Each thread computes one element of the phase matrix
-    int vis_idx = blockIdx.x * blockDim.x + threadIdx.x;
-    int pixel_idx = blockIdx.y * blockDim.y + threadIdx.y;
-    
-    if (vis_idx < num_vis && pixel_idx < num_pixels) {
-        // Load coordinates with high precision
-        double u = u_coords[vis_idx];
-        double v = v_coords[vis_idx];
-        double w = w_coords[vis_idx];
-        double l = l_coords[pixel_idx];
-        double m = m_coords[pixel_idx];
-        double n = n_coords[pixel_idx] - 1.0; // n - 1
-        
-        // Careful phase computation to maintain precision
-        double ul = u * l;
-        double vm = v * m;
-        double wn = w * n;
-        
-        double sum1 = ul + vm;
-        double sum2 = sum1 + wn;
-        
-        // Positive sign for inverse DFT (key difference)
-        double phase = 2.0 * PI_DOUBLE * sum2;
-        
-        // Store phase in matrix
-        phase_matrix[vis_idx * num_pixels + pixel_idx] = phase;
-    }
+    const double *__restrict__ l_coords, const double *__restrict__ m_coords,
+    const double *__restrict__ n_coords, const double *__restrict__ u_coords,
+    const double *__restrict__ v_coords, const double *__restrict__ w_coords,
+    double *__restrict__ phase_matrix, int num_vis, int num_pixels) {
+  // Each thread computes one element of the phase matrix
+  int vis_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  int pixel_idx = blockIdx.y * blockDim.y + threadIdx.y;
+
+  if (vis_idx < num_vis && pixel_idx < num_pixels) {
+    // Load coordinates with high precision
+    double u = u_coords[vis_idx];
+    double v = v_coords[vis_idx];
+    double w = w_coords[vis_idx];
+    double l = l_coords[pixel_idx];
+    double m = m_coords[pixel_idx];
+    double n = n_coords[pixel_idx] - 1.0; // n - 1
+
+    // Careful phase computation to maintain precision
+    double ul = u * l;
+    double vm = v * m;
+    double wn = w * n;
+
+    double sum1 = ul + vm;
+    double sum2 = sum1 + wn;
+
+    // Positive sign for inverse DFT (key difference)
+    double phase = 2.0 * PI_DOUBLE * sum2;
+
+    // Store phase in matrix
+    phase_matrix[vis_idx * num_pixels + pixel_idx] = phase;
+  }
 }
 
 // Adding an inverse DFT version of the phase kernel
 
-torch::Tensor compute_inverse_phase_matrix(
-    torch::Tensor l_coords,
-    torch::Tensor m_coords,
-    torch::Tensor n_coords,
-    torch::Tensor u_coords,
-    torch::Tensor v_coords,
-    torch::Tensor w_coords
-) {
-    // Input validation identical to the forward version
-    TORCH_CHECK(l_coords.is_cuda(), "l_coords must be a CUDA tensor");
-    TORCH_CHECK(m_coords.is_cuda(), "m_coords must be a CUDA tensor");
-    TORCH_CHECK(n_coords.is_cuda(), "n_coords must be a CUDA tensor");
-    TORCH_CHECK(u_coords.is_cuda(), "u_coords must be a CUDA tensor");
-    TORCH_CHECK(v_coords.is_cuda(), "v_coords must be a CUDA tensor");
-    TORCH_CHECK(w_coords.is_cuda(), "w_coords must be a CUDA tensor");
-    
-    int num_pixels = l_coords.size(0);
-    int num_vis = u_coords.size(0);
-    
-    // Create output tensor
-    auto options = torch::TensorOptions()
-                       .dtype(torch::kFloat64)
-                       .device(l_coords.device());
-    auto phase_matrix = torch::empty({num_vis, num_pixels}, options);
-    
-    // Set up kernel execution
-    dim3 threads_per_block(16, 16);
-    dim3 num_blocks(
-        (num_vis + threads_per_block.x - 1) / threads_per_block.x,
-        (num_pixels + threads_per_block.y - 1) / threads_per_block.y
-    );
-    
-    // Launch inverse kernel (with positive sign)
-    compute_high_precision_inverse_phase_kernel<<<num_blocks, threads_per_block>>>(
-        l_coords.data_ptr<double>(),
-        m_coords.data_ptr<double>(),
-        n_coords.data_ptr<double>(),
-        u_coords.data_ptr<double>(),
-        v_coords.data_ptr<double>(),
-        w_coords.data_ptr<double>(),
-        phase_matrix.data_ptr<double>(),
-        num_vis,
-        num_pixels
-    );
-    
-    return phase_matrix;
-}
+torch::Tensor
+compute_inverse_phase_matrix(torch::Tensor l_coords, torch::Tensor m_coords,
+                             torch::Tensor n_coords, torch::Tensor u_coords,
+                             torch::Tensor v_coords, torch::Tensor w_coords) {
+  // Input validation identical to the forward version
+  TORCH_CHECK(l_coords.is_cuda(), "l_coords must be a CUDA tensor");
+  TORCH_CHECK(m_coords.is_cuda(), "m_coords must be a CUDA tensor");
+  TORCH_CHECK(n_coords.is_cuda(), "n_coords must be a CUDA tensor");
+  TORCH_CHECK(u_coords.is_cuda(), "u_coords must be a CUDA tensor");
+  TORCH_CHECK(v_coords.is_cuda(), "v_coords must be a CUDA tensor");
+  TORCH_CHECK(w_coords.is_cuda(), "w_coords must be a CUDA tensor");
 
+  int num_pixels = l_coords.size(0);
+  int num_vis = u_coords.size(0);
 
-// PyBind11 module definition
-PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-    m.def("compute_inverse_phase_matrix", &compute_inverse_phase_matrix, "Compute inverse phase matrix with high precision");
-    m.def("compute_phase_matrix", &compute_phase_matrix, "Compute phase matrix with high precision");
+  // Create output tensor
+  auto options =
+      torch::TensorOptions().dtype(torch::kFloat64).device(l_coords.device());
+  auto phase_matrix = torch::empty({num_vis, num_pixels}, options);
+
+  // Set up kernel execution
+  dim3 threads_per_block(16, 16);
+  dim3 num_blocks((num_vis + threads_per_block.x - 1) / threads_per_block.x,
+                  (num_pixels + threads_per_block.y - 1) / threads_per_block.y);
+
+  // Launch inverse kernel (with positive sign)
+  compute_high_precision_inverse_phase_kernel<<<num_blocks,
+                                                threads_per_block>>>(
+      l_coords.data_ptr<double>(), m_coords.data_ptr<double>(),
+      n_coords.data_ptr<double>(), u_coords.data_ptr<double>(),
+      v_coords.data_ptr<double>(), w_coords.data_ptr<double>(),
+      phase_matrix.data_ptr<double>(), num_vis, num_pixels);
+
+  return phase_matrix;
 }

--- a/radioft/cuda/kernels/cuda_phase_kernel32.cu
+++ b/radioft/cuda/kernels/cuda_phase_kernel32.cu
@@ -1,0 +1,160 @@
+#include <cuComplex.h>
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <torch/extension.h>
+
+// Constants for numerical stability
+#define PI 3.1415927
+
+/**
+ * Phase calculation kernel
+ * This kernel computes the phase matrix with float32 precision
+ */
+__global__ void compute_phase_kernel32(
+    const float *__restrict__ l_coords, const float *__restrict__ m_coords,
+    const float *__restrict__ n_coords, const float *__restrict__ u_coords,
+    const float *__restrict__ v_coords, const float *__restrict__ w_coords,
+    float *__restrict__ phase_matrix, int num_vis, int num_pixels) {
+  // Each thread computes one element of the phase matrix
+  int vis_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  int pixel_idx = blockIdx.y * blockDim.y + threadIdx.y;
+
+  if (vis_idx < num_vis && pixel_idx < num_pixels) {
+    // Load coordinates with float32 precision
+    float u = u_coords[vis_idx];
+    float v = v_coords[vis_idx];
+    float w = w_coords[vis_idx];
+    float l = l_coords[pixel_idx];
+    float m = m_coords[pixel_idx];
+    float n = n_coords[pixel_idx] - 1.0; // n - 1
+
+    // Careful phase computation to maintain precision
+    // Calculate components separately to minimize rounding errors
+    float ul = u * l;
+    float vm = v * m;
+    float wn = w * n;
+
+    // Combine terms carefully
+    float sum1 = ul + vm;
+    float sum2 = sum1 + wn;
+
+    // Final phase calculation
+    float phase = -2.0 * PI * sum2;
+
+    // Store phase in matrix
+    phase_matrix[vis_idx * num_pixels + pixel_idx] = phase;
+  }
+}
+
+// Wrapper functions for PyTorch integration
+
+torch::Tensor
+compute_phase_matrix32(torch::Tensor l_coords, torch::Tensor m_coords,
+                       torch::Tensor n_coords, torch::Tensor u_coords,
+                       torch::Tensor v_coords, torch::Tensor w_coords) {
+  // Validate inputs
+  TORCH_CHECK(l_coords.is_cuda(), "l_coords must be a CUDA tensor");
+  TORCH_CHECK(m_coords.is_cuda(), "m_coords must be a CUDA tensor");
+  TORCH_CHECK(n_coords.is_cuda(), "n_coords must be a CUDA tensor");
+  TORCH_CHECK(u_coords.is_cuda(), "u_coords must be a CUDA tensor");
+  TORCH_CHECK(v_coords.is_cuda(), "v_coords must be a CUDA tensor");
+  TORCH_CHECK(w_coords.is_cuda(), "w_coords must be a CUDA tensor");
+
+  int num_pixels = l_coords.size(0);
+  int num_vis = u_coords.size(0);
+
+  // Create output tensor
+  auto options =
+      torch::TensorOptions().dtype(torch::kFloat32).device(l_coords.device());
+  auto phase_matrix = torch::empty({num_vis, num_pixels}, options);
+
+  // Set up kernel execution
+  dim3 threads_per_block(16, 16);
+  dim3 num_blocks((num_vis + threads_per_block.x - 1) / threads_per_block.x,
+                  (num_pixels + threads_per_block.y - 1) / threads_per_block.y);
+
+  // Launch kernel
+  compute_phase_kernel32<<<num_blocks, threads_per_block>>>(
+      l_coords.data_ptr<float>(), m_coords.data_ptr<float>(),
+      n_coords.data_ptr<float>(), u_coords.data_ptr<float>(),
+      v_coords.data_ptr<float>(), w_coords.data_ptr<float>(),
+      phase_matrix.data_ptr<float>(), num_vis, num_pixels);
+
+  return phase_matrix;
+}
+
+/**
+ * Inverse phase calculation kernel
+ * This kernel computes the phase matrix with float32
+ * and POSITIVE sign for inverse DFT
+ */
+__global__ void compute_inverse_phase_kernel32(
+    const float *__restrict__ l_coords, const float *__restrict__ m_coords,
+    const float *__restrict__ n_coords, const float *__restrict__ u_coords,
+    const float *__restrict__ v_coords, const float *__restrict__ w_coords,
+    float *__restrict__ phase_matrix, int num_vis, int num_pixels) {
+  // Each thread computes one element of the phase matrix
+  int vis_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  int pixel_idx = blockIdx.y * blockDim.y + threadIdx.y;
+
+  if (vis_idx < num_vis && pixel_idx < num_pixels) {
+    // Load coordinates with float32 precision
+    float u = u_coords[vis_idx];
+    float v = v_coords[vis_idx];
+    float w = w_coords[vis_idx];
+    float l = l_coords[pixel_idx];
+    float m = m_coords[pixel_idx];
+    float n = n_coords[pixel_idx] - 1.0; // n - 1
+
+    // Careful phase computation to maintain precision
+    float ul = u * l;
+    float vm = v * m;
+    float wn = w * n;
+
+    float sum1 = ul + vm;
+    float sum2 = sum1 + wn;
+
+    // Positive sign for inverse DFT (key difference)
+    float phase = 2.0 * PI * sum2;
+
+    // Store phase in matrix
+    phase_matrix[vis_idx * num_pixels + pixel_idx] = phase;
+  }
+}
+
+// Adding an inverse DFT version of the phase kernel
+
+torch::Tensor
+compute_inverse_phase_matrix32(torch::Tensor l_coords, torch::Tensor m_coords,
+                               torch::Tensor n_coords, torch::Tensor u_coords,
+                               torch::Tensor v_coords, torch::Tensor w_coords) {
+  // Input validation identical to the forward version
+  TORCH_CHECK(l_coords.is_cuda(), "l_coords must be a CUDA tensor");
+  TORCH_CHECK(m_coords.is_cuda(), "m_coords must be a CUDA tensor");
+  TORCH_CHECK(n_coords.is_cuda(), "n_coords must be a CUDA tensor");
+  TORCH_CHECK(u_coords.is_cuda(), "u_coords must be a CUDA tensor");
+  TORCH_CHECK(v_coords.is_cuda(), "v_coords must be a CUDA tensor");
+  TORCH_CHECK(w_coords.is_cuda(), "w_coords must be a CUDA tensor");
+
+  int num_pixels = l_coords.size(0);
+  int num_vis = u_coords.size(0);
+
+  // Create output tensor
+  auto options =
+      torch::TensorOptions().dtype(torch::kFloat32).device(l_coords.device());
+  auto phase_matrix = torch::empty({num_vis, num_pixels}, options);
+
+  // Set up kernel execution
+  dim3 threads_per_block(16, 16);
+  dim3 num_blocks((num_vis + threads_per_block.x - 1) / threads_per_block.x,
+                  (num_pixels + threads_per_block.y - 1) / threads_per_block.y);
+
+  // Launch inverse kernel (with positive sign)
+  compute_inverse_phase_kernel32<<<num_blocks, threads_per_block>>>(
+      l_coords.data_ptr<float>(), m_coords.data_ptr<float>(),
+      n_coords.data_ptr<float>(), u_coords.data_ptr<float>(),
+      v_coords.data_ptr<float>(), w_coords.data_ptr<float>(),
+      phase_matrix.data_ptr<float>(), num_vis, num_pixels);
+
+  return phase_matrix;
+}

--- a/radioft/dft/dft.py
+++ b/radioft/dft/dft.py
@@ -12,14 +12,12 @@ class HybridPyTorchCudaDFT:
     Deterministic hybrid PyTorch-CUDA DFT implementation with performance optimizations
     """
 
-    def __init__(self, device="cuda", benchmark=False, dtype=torch.double):
+    def __init__(self, device="cuda", benchmark=False):
         self.device = device
 
         # Set deterministic algorithms for more consistent performance
         torch.backends.cudnn.deterministic = True
         torch.backends.cudnn.benchmark = benchmark
-
-        self.dtype = dtype
 
         self.dft = cuda_dft
         self.idft = cuda_idft

--- a/radioft/dft/dft.py
+++ b/radioft/dft/dft.py
@@ -345,7 +345,7 @@ class OptimizedPyTorchDFT:
                 # Combine terms and compute phase
                 # Using a single combined phase calculation avoids intermediate
                 # allocations
-                phase = -2.0 * torch.pi * (u_term + v_term + w_term)
+                phase = -2.0 * pi * (u_term + v_term + w_term)
 
                 # Pre-compute trig functions (more efficient than complex
                 # exponentiation)

--- a/radioft/dft/dft.py
+++ b/radioft/dft/dft.py
@@ -2,6 +2,7 @@ from math import pi
 
 import torch
 
+from radioft.utils._typing import isdouble
 from radioft.utils.sizes import get_optimal_chunk_sizes
 
 from .utils import cuda_dft, cuda_idft
@@ -32,7 +33,7 @@ class HybridPyTorchCudaDFT:
         v_coords,
         w_coords,
         max_memory_gb=4,
-        float64=False,
+        dtype=torch.double,
     ):
         """
         Compute DFT with predictable performance
@@ -42,14 +43,14 @@ class HybridPyTorchCudaDFT:
 
         # Convert to appropriate format
         sky_values = sky_values.to(
-            self.device, torch.complex128 if float64 else torch.complex64
+            self.device, torch.complex128 if isdouble(dtype) else torch.complex64
         )
-        l_coords = l_coords.to(self.device, torch.float64 if float64 else torch.float32)
-        m_coords = m_coords.to(self.device, torch.float64 if float64 else torch.float32)
-        n_coords = n_coords.to(self.device, torch.float64 if float64 else torch.float32)
-        u_coords = u_coords.to(self.device, torch.float64 if float64 else torch.float32)
-        v_coords = v_coords.to(self.device, torch.float64 if float64 else torch.float32)
-        w_coords = w_coords.to(self.device, torch.float64 if float64 else torch.float32)
+        l_coords = l_coords.to(self.device, dtype)
+        m_coords = m_coords.to(self.device, dtype)
+        n_coords = n_coords.to(self.device, dtype)
+        u_coords = u_coords.to(self.device, dtype)
+        v_coords = v_coords.to(self.device, dtype)
+        w_coords = w_coords.to(self.device, dtype)
 
         # Handle batched or unbatched input
         if sky_values.dim() == 1:
@@ -110,7 +111,7 @@ class HybridPyTorchCudaDFT:
                     u_chunk,
                     v_chunk,
                     w_chunk,
-                    float64=True if float64 else False,
+                    dtype=dtype,
                 )
             # Store result for this visibility chunk
             visibilities[:, vis_start:vis_end] = chunk_vis
@@ -134,7 +135,7 @@ class HybridPyTorchCudaDFT:
         v_coords,
         w_coords,
         max_memory_gb=20,
-        float64=False,
+        dtype=torch.double,
     ):
         """
         Compute inverse DFT with built-in chunking like the forward method
@@ -144,14 +145,14 @@ class HybridPyTorchCudaDFT:
 
         # Convert to appropriate format
         visibilities = visibilities.to(
-            self.device, torch.complex128 if float64 else torch.complex64
+            self.device, torch.complex128 if isdouble(dtype) else torch.complex64
         )
-        l_coords = l_coords.to(self.device, torch.float64 if float64 else torch.float32)
-        m_coords = m_coords.to(self.device, torch.float64 if float64 else torch.float32)
-        n_coords = n_coords.to(self.device, torch.float64 if float64 else torch.float32)
-        u_coords = u_coords.to(self.device, torch.float64 if float64 else torch.float32)
-        v_coords = v_coords.to(self.device, torch.float64 if float64 else torch.float32)
-        w_coords = w_coords.to(self.device, torch.float64 if float64 else torch.float32)
+        l_coords = l_coords.to(self.device, dtype)
+        m_coords = m_coords.to(self.device, dtype)
+        n_coords = n_coords.to(self.device, dtype)
+        u_coords = u_coords.to(self.device, dtype)
+        v_coords = v_coords.to(self.device, dtype)
+        w_coords = w_coords.to(self.device, dtype)
 
         # Handle batched or unbatched input
         if visibilities.dim() == 1:
@@ -212,7 +213,7 @@ class HybridPyTorchCudaDFT:
                     u_chunk,
                     v_chunk,
                     w_chunk,
-                    float64=True if float64 else False,
+                    dtype=dtype,
                 )
 
             # Add contribution to the sky values

--- a/radioft/dft/utils.py
+++ b/radioft/dft/utils.py
@@ -7,6 +7,7 @@ from radioft.cuda.kernels import (
     compute_phase_matrix,
     compute_phase_matrix32,
 )
+from radioft.utils._typing import isdouble
 
 
 class CudaDFTFunction(Function):
@@ -20,7 +21,7 @@ class CudaDFTFunction(Function):
         u_coords,
         v_coords,
         w_coords,
-        float64=False,
+        dtype=torch.double,
     ):
         # Save for backward
         ctx.save_for_backward(
@@ -28,7 +29,7 @@ class CudaDFTFunction(Function):
         )
 
         # Get phase matrix from CUDA kernel
-        if float64:
+        if isdouble(dtype):
             phase_matrix = compute_phase_matrix(
                 l_coords, m_coords, n_coords, u_coords, v_coords, w_coords
             )
@@ -55,12 +56,12 @@ class CudaDFTFunction(Function):
         num_vis = phase_matrix.shape[0]
         vis_real = torch.zeros(
             (batch_size, num_vis),
-            dtype=torch.float64 if float64 else torch.float32,
+            dtype=dtype,
             device=sky_values.device,
         )
         vis_imag = torch.zeros(
             (batch_size, num_vis),
-            dtype=torch.float64 if float64 else torch.float32,
+            dtype=dtype,
             device=sky_values.device,
         )
 
@@ -160,7 +161,7 @@ class CudaIDFTFunction(Function):
         u_coords,
         v_coords,
         w_coords,
-        float64=False,
+        dtype=torch.double,
     ):
         """
         Simplified forward pass that computes inverse DFT for a single chunk
@@ -196,7 +197,7 @@ class CudaIDFTFunction(Function):
         )
 
         # Compute phase matrix
-        if float64:
+        if isdouble(dtype):
             phase_matrix = compute_inverse_phase_matrix(
                 l_coords, m_coords, n_coords, u_coords, v_coords, w_coords
             )
@@ -323,7 +324,7 @@ def cuda_dft(
     u_coords,
     v_coords,
     w_coords,
-    float64=False,
+    dtype=torch.double,
 ):
     """
     CUDA-accelerated DFT without chunking - for use by HybridPyTorchCudaDFT
@@ -336,7 +337,7 @@ def cuda_dft(
         u_coords,
         v_coords,
         w_coords,
-        float64,
+        dtype,
     )
 
 
@@ -348,7 +349,7 @@ def cuda_idft(
     u_coords,
     v_coords,
     w_coords,
-    float64=False,
+    dtype=torch.double,
 ):
     """
     CUDA-accelerated IDFT without chunking - for use by HybridPyTorchCudaDFT
@@ -361,5 +362,5 @@ def cuda_idft(
         u_coords,
         v_coords,
         w_coords,
-        float64,
+        dtype,
     )

--- a/radioft/dft/utils.py
+++ b/radioft/dft/utils.py
@@ -305,19 +305,51 @@ class CudaIDFTFunction(Function):
 
 
 # Create wrapper functions for ease of use
-def cuda_dft(sky_values, l_coords, m_coords, n_coords, u_coords, v_coords, w_coords):
+def cuda_dft(
+    sky_values,
+    l_coords,
+    m_coords,
+    n_coords,
+    u_coords,
+    v_coords,
+    w_coords,
+    float64=False,
+):
     """
     CUDA-accelerated DFT without chunking - for use by HybridPyTorchCudaDFT
     """
     return CudaDFTFunction.apply(
-        sky_values, l_coords, m_coords, n_coords, u_coords, v_coords, w_coords
+        sky_values,
+        l_coords,
+        m_coords,
+        n_coords,
+        u_coords,
+        v_coords,
+        w_coords,
+        float64,
     )
 
 
-def cuda_idft(visibilities, l_coords, m_coords, n_coords, u_coords, v_coords, w_coords):
+def cuda_idft(
+    visibilities,
+    l_coords,
+    m_coords,
+    n_coords,
+    u_coords,
+    v_coords,
+    w_coords,
+    float64=False,
+):
     """
     CUDA-accelerated IDFT without chunking - for use by HybridPyTorchCudaDFT
     """
     return CudaIDFTFunction.apply(
-        visibilities, l_coords, m_coords, n_coords, u_coords, v_coords, w_coords
+        visibilities,
+        l_coords,
+        m_coords,
+        n_coords,
+        u_coords,
+        v_coords,
+        w_coords,
+        float64,
     )

--- a/radioft/dft/utils.py
+++ b/radioft/dft/utils.py
@@ -94,9 +94,14 @@ class CudaDFTFunction(Function):
         # We only care about gradient with respect to sky_values for the neural network
         if ctx.needs_input_grad[0]:
             # Get phase matrix again
-            phase_matrix = compute_phase_matrix(
-                l_coords, m_coords, n_coords, u_coords, v_coords, w_coords
-            )
+            if l_coords.dtype == torch.float64:
+                phase_matrix = compute_phase_matrix(
+                    l_coords, m_coords, n_coords, u_coords, v_coords, w_coords
+                )
+            else:
+                phase_matrix = compute_phase_matrix32(
+                    l_coords, m_coords, n_coords, u_coords, v_coords, w_coords
+                )
 
             # Compute trig functions
             cos_phase = torch.cos(phase_matrix)
@@ -141,7 +146,7 @@ class CudaDFTFunction(Function):
                 grad_sky = grad_sky.squeeze(0)
 
         # Return gradients for all inputs
-        return grad_sky, grad_l, grad_m, grad_n, grad_u, grad_v, grad_w
+        return grad_sky, grad_l, grad_m, grad_n, grad_u, grad_v, grad_w, None
 
 
 class CudaIDFTFunction(Function):
@@ -270,9 +275,14 @@ class CudaIDFTFunction(Function):
             # Compute phase matrix for gradient computation (use forward phase)
             # For backward pass through IDFT, we need the complex conjugate
             # of the forward phase factors (which is the regular DFT phase)
-            phase_matrix = compute_phase_matrix(
-                l_coords, m_coords, n_coords, u_coords, v_coords, w_coords
-            )
+            if l_coords.dtype == torch.float64:
+                phase_matrix = compute_phase_matrix(
+                    l_coords, m_coords, n_coords, u_coords, v_coords, w_coords
+                )
+            else:
+                phase_matrix = compute_phase_matrix32(
+                    l_coords, m_coords, n_coords, u_coords, v_coords, w_coords
+                )
 
             # Compute trig functions
             cos_phase = torch.cos(phase_matrix)  # [num_vis, num_pixels]
@@ -301,7 +311,7 @@ class CudaIDFTFunction(Function):
                 grad_vis = grad_vis.squeeze(0)
 
         # Return gradients for all inputs
-        return grad_vis, grad_l, grad_m, grad_n, grad_u, grad_v, grad_w
+        return grad_vis, grad_l, grad_m, grad_n, grad_u, grad_v, grad_w, None
 
 
 # Create wrapper functions for ease of use

--- a/radioft/utils/_typing.py
+++ b/radioft/utils/_typing.py
@@ -1,0 +1,5 @@
+import torch
+
+
+def isdouble(dtype):
+    return dtype is (torch.double or torch.float64)

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,10 @@
 import os
-from pathlib import Path
 import platform
 import subprocess
-from setuptools import setup, find_packages
-from torch.utils.cpp_extension import BuildExtension, CUDAExtension, CUDA_HOME
+from pathlib import Path
+
+from setuptools import find_packages, setup
+from torch.utils.cpp_extension import CUDA_HOME, BuildExtension, CUDAExtension
 
 # Check if CUDA is available
 cuda_available = CUDA_HOME is not None
@@ -34,6 +35,7 @@ if cuda_available:
     # cuda_sources = [str(p) for p in Path("radioft/cuda").glob("**/*.cu")]
     cuda_dir = Path("radioft/cuda")
     cuda_sources = list(cuda_dir.glob("**/*.cu"))
+    cuda_sources.append(cuda_dir / "cuda_bindings.cpp")
 
     gencode = f"arch=compute_{compute_capability},code=sm_{compute_capability}"
 


### PR DESCRIPTION
This pull request introduces significant updates to the CUDA-based DFT implementation, including support for both float32 and float64 precision, improved modularity, and updated dependencies. The changes enhance numerical precision flexibility, optimize performance, and improve maintainability. Below are the most important changes grouped by theme.

### Dependency and Configuration Updates
* Updated `.pre-commit-config.yaml` to include the `ruff` linter and updated versions of `isort` and `flake8`. Removed `black` from the configuration. 

### CUDA Kernels and Bindings Enhancements
* Added new CUDA kernels (`compute_phase_kernel32` and `compute_inverse_phase_kernel32`) in `radioft/cuda/kernels/cuda_phase_kernel32.cu` to support float32 precision for phase matrix computations.
* Refactored existing kernels in `radioft/cuda/kernels/cuda_phase_kernel.cu` to improve code formatting and readability, including consistent formatting for function signatures and kernel launches. 
* Added PyBind11 bindings in `radioft/cuda/cuda_bindings.cpp` to expose both float32 and float64 CUDA kernel functions to Python. 

### PyTorch Integration and API Improvements
* Updated `radioft/dft/dft.py` to add support for both float32 and float64 precision in the `HybridPyTorchCudaDFT` class. Introduced a `dtype` parameter in the constructor and `float64` flags in the `forward` and `inverse` methods to toggle precision. 
* Modified tensor initialization and typecasting in `forward` and `inverse` methods to dynamically set precision based on the `float64` flag.
