### PR TITLE
Finufft

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,8 @@ dependencies = [
   "toml",
   "torch>=2.7.0",
   "tqdm",
+  "cupy-cuda12x",
+  "cufinufft",
 ]
 
 [project.optional-dependencies]

--- a/radioft/dft/__init__.py
+++ b/radioft/dft/__init__.py
@@ -1,0 +1,3 @@
+from .dft import HybridPyTorchCudaDFT
+
+__all__ = ["HybridPyTorchCudaDFT"]

--- a/radioft/finufft/__init__.py
+++ b/radioft/finufft/__init__.py
@@ -1,0 +1,3 @@
+from .finufft import CupyFinufft
+
+__all__ = ["CupyFinufft"]

--- a/radioft/finufft/finufft.py
+++ b/radioft/finufft/finufft.py
@@ -1,0 +1,102 @@
+from functools import partial
+from math import pi
+
+import cufinufft
+import cupy as cp
+
+
+class CupyFinufft:
+    """Wraper to use Finufft Type 3d3 for radio interferometry data."""
+
+    def __init__(
+        self,
+        image_size,
+        fov_arcsec,
+        eps=1e-12,
+    ):
+        """Docstring"""
+        self.px_size = ((fov_arcsec / 3600) * pi / 180) / image_size
+        self.px_scaling = image_size**2
+
+        self.ft = partial(cufinufft.nufft3d3, isign=1, eps=eps)
+        self.ift = partial(cufinufft.nufft3d3, isign=-1, eps=eps)
+
+    def nufft(
+        self,
+        sky_values,
+        l_coords,
+        m_coords,
+        n_coords,
+        u_coords,
+        v_coords,
+        w_coords,
+    ):
+        """Docstring"""
+        # Antenna coordinates (Fourier Domain - uvw coordinates)
+        source_u = cp.asarray(
+            2 * pi * (u_coords.flatten() * self.px_size), dtype=cp.float64
+        ) % (2 * pi)
+        source_v = cp.asarray(
+            2 * pi * (v_coords.flatten() * self.px_size), dtype=cp.float64
+        ) % (2 * pi)
+        source_w = cp.asarray(
+            2 * pi * (w_coords.flatten() * self.px_size), dtype=cp.float64
+        ) % (2 * pi)
+
+        # Values at source points (Source intensities)
+        c_values = cp.asarray(sky_values.flatten(), dtype=cp.complex128)
+
+        # Target coordinates (Image domain - lmn coordinates)
+        target_l = cp.asarray((l_coords / self.px_size), dtype=cp.float64)
+        target_m = cp.asarray((m_coords / self.px_size), dtype=cp.float64)
+        target_n = cp.asarray((n_coords / self.px_size), dtype=cp.float64)
+
+        result = (
+            self.ft(
+                source_u, source_v, source_w, c_values, target_l, target_m, target_n
+            )
+            / self.px_scaling
+        )
+        visibilities = result.get()
+
+        return visibilities
+
+    def inufft(
+        self,
+        visibilities,
+        l_coords,
+        m_coords,
+        n_coords,
+        u_coords,
+        v_coords,
+        w_coords,
+    ):
+        """Docstring"""
+        # Antenna coordinates (Fourier Domain - uvw coordinates)
+        source_u = cp.asarray(
+            2 * pi * (u_coords.flatten() * self.px_size), dtype=cp.float64
+        ) % (2 * pi)
+        source_v = cp.asarray(
+            2 * pi * (v_coords.flatten() * self.px_size), dtype=cp.float64
+        ) % (2 * pi)
+        source_w = cp.asarray(
+            2 * pi * (w_coords.flatten() * self.px_size), dtype=cp.float64
+        ) % (2 * pi)
+
+        # Values at source points (Source intensities)
+        c_values = cp.asarray(visibilities.flatten(), dtype=cp.complex128)
+
+        # Target coordinates (Image domain - lmn coordinates)
+        target_l = cp.asarray((l_coords / self.px_size), dtype=cp.float64)
+        target_m = cp.asarray((m_coords / self.px_size), dtype=cp.float64)
+        target_n = cp.asarray((n_coords / self.px_size), dtype=cp.float64)
+
+        result = (
+            self.ft(
+                source_u, source_v, source_w, c_values, target_l, target_m, target_n
+            )
+            / self.px_scaling
+        )
+        sky_intensities = result.get()
+
+        return sky_intensities


### PR DESCRIPTION
This pull request adds GPU-accelerated non-uniform FFT (NUFFT) support using CuPy and cuFINUFFT for radio interferometry data processing. The main changes introduce new dependencies, a wrapper class for cuFINUFFT.

### GPU-accelerated NUFFT functionality

* Added `CupyFinufft` class in `radioft/finufft/finufft.py`, which wraps cuFINUFFT's Type 3d3 transform for efficient radio interferometry computations on the GPU. This includes both forward (`nufft`) and inverse (`inufft`) transforms, handling coordinate conversions and scaling.

### Dependency updates

* Added `cupy-cuda12x` and `cufinufft` to the `pyproject.toml` dependencies to enable GPU-based FFT operations.

### Module exports

* Updated `radioft/finufft/__init__.py` to export the new `CupyFinufft` class.
* Updated `radioft/dft/__init__.py` to export the `HybridPyTorchCudaDFT` class.