### PR TITLE
Remove torch_to_cupy and cupy_to_torch functions

### DIFF
--- a/docs/changes/27.maintenance.rst
+++ b/docs/changes/27.maintenance.rst
@@ -1,0 +1,1 @@
+Removed cupy_to_torch and torch_to_cupy functions and use `array_namespace.from_dlpack` instead to convert arrays


### PR DESCRIPTION
Cupy's `fromDlpack` and `toDlpack` as well as PyTorch's `torch.utils.dlpack.to_dlpack` methods are deprecated.

Packages following the array API standard like Cupy and PyTorch now provide the `__dlpack__` method which allows conversion through the `array_namespace.from_dlpack` method.

```python
import torch
import cupy as cp

test_tensor = torch.tensor([1])
print("__dlpack__" in dir(test_tensor))  # True

test_array = cp.array([1])
print("__dlpack__" in dir(test_array))  # True
```